### PR TITLE
Add hubot-lunchpoll

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -9,5 +9,6 @@
   "hubot-redis-brain",
   "hubot-rules",
   "hubot-shipit",
-  "hubot-youtube"
+  "hubot-youtube",
+  "hubot-lunchpoll"
 ]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "hubot-scripts": "^2.5.16",
     "hubot-shipit": "^0.1.2",
     "hubot-slack": "slackhq/hubot-slack#ea562aeadab3f9f58e8db6ee5e86a4a41509db6a",
-    "hubot-youtube": "^0.1.2"
+    "hubot-youtube": "^0.1.2",
+    "hubot-lunchpoll": "azevedo-252/hubot-lunchpoll"
   },
   "engines": {
     "node": "0.10.x"

--- a/scripts/lunch.js
+++ b/scripts/lunch.js
@@ -48,7 +48,7 @@ var requestAccessToken = function(callback) {
 };
 
 module.exports = function(robot) {
-  robot.respond(/lunch/i, function(response) {
+  robot.respond(/^lunch$/i, function(response) {
     try {
       requestAccessToken(function(error) {
         if (error)


### PR DESCRIPTION
Why:
- Wanted to try a new way of deciding where to lunch in Braga

This change addresses the need by:
- Using [hubot-lunchpoll](https://github.com/azevedo-252/hubot-lunchpoll) for suggesting
  random restaurants and allowing each team member to vote for their
  choice
